### PR TITLE
Added option to Clean the project in a Xamarin Android Build Task.

### DIFF
--- a/Tasks/XamarinAndroid/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/de-de/resources.resjson
@@ -11,6 +11,8 @@
   "loc.input.help.target": "Erstellt diese Ziele in diesem Projekt. Trennen Sie mehrere Ziele mit einem Semikolon.",
   "loc.input.label.outputDir": "Ausgabeverzeichnis",
   "loc.input.label.configuration": "Konfiguration",
+  "loc.input.label.clean": "Bereinigen",
+  "loc.input.help.clean": "Führt einen bereinigten Build (\"/t:clean\") vor dem Build aus.",
   "loc.input.label.msbuildLocation": "MSBuild-Speicherort",
   "loc.input.help.msbuildLocation": "Geben Sie optional den Pfad zu MSBuild an. Standardmäßig wird nach der aktuellen Version gesucht.",
   "loc.input.label.msbuildArguments": "MSBuild-Argumente",

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/en-US/resources.resjson
@@ -12,6 +12,8 @@
   "loc.input.label.outputDir": "Output Directory",
   "loc.input.help.outputDir": "Optionally provide the output directory for the build. Example: $(build.binariesDirectory)/bin/Release.",
   "loc.input.label.configuration": "Configuration",
+  "loc.input.label.clean": "Clean",
+  "loc.input.help.clean": "Run a clean build (/t:clean) prior to the build.",
   "loc.input.label.msbuildLocation": "MSBuild Location",
   "loc.input.help.msbuildLocation": "Optionally supply the path to MSBuild (on Windows) or xbuild (on Mac).  It defaults to searching for latest version.",
   "loc.input.label.msbuildArguments": "Additional Arguments",

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/es-es/resources.resjson
@@ -11,6 +11,8 @@
   "loc.input.help.target": "Compile estos destinos en este proyecto. Use puntos y comas para separar distintos destinos.",
   "loc.input.label.outputDir": "Directorio de salida",
   "loc.input.label.configuration": "Configuración",
+  "loc.input.label.clean": "Limpiar",
+  "loc.input.help.clean": "Ejecute una compilación limpia (/t:clean) antes de realizar la compilación.",
   "loc.input.label.msbuildLocation": "Ubicación de MSBuild",
   "loc.input.help.msbuildLocation": "Proporcione opcionalmente la ruta de acceso a MSBuild. Se establece de forma predeterminada para buscar la última versión.",
   "loc.input.label.msbuildArguments": "Argumentos de MSBuild",

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/fr-fr/resources.resjson
@@ -11,6 +11,8 @@
   "loc.input.help.target": "Générez ces cibles dans ce projet. Utilisez un point-virgule pour séparer plusieurs cibles.",
   "loc.input.label.outputDir": "Répertoire de sortie",
   "loc.input.label.configuration": "Configuration",
+  "loc.input.label.clean": "Nettoyer",
+  "loc.input.help.clean": "Exécutez un nettoyage de build (/t:clean) avant d'effectuer la génération.",
   "loc.input.label.msbuildLocation": "Emplacement de MSBuild",
   "loc.input.help.msbuildLocation": "Indiquez éventuellement le chemin d'accès à MSBuild. Il s'agit généralement de rechercher la dernière version.",
   "loc.input.label.msbuildArguments": "Arguments MSBuild",

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/it-IT/resources.resjson
@@ -11,6 +11,8 @@
   "loc.input.help.target": "Consente di compilare queste destinazioni nel progetto. Usare il punto e virgola per separare più destinazioni.",
   "loc.input.label.outputDir": "Directory di output",
   "loc.input.label.configuration": "Configurazione",
+  "loc.input.label.clean": "Pulisci",
+  "loc.input.help.clean": "Esegue una compilazione pulita (/t:clean) prima della compilazione.",
   "loc.input.label.msbuildLocation": "Percorso MSBuild",
   "loc.input.help.msbuildLocation": "Consente, facoltativamente, di specificare il percorso di MSBuild. Per impostazione predefinita, verrà cercata la versione più recente.",
   "loc.input.label.msbuildArguments": "Argomenti MSBuild",

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/ja-jp/resources.resjson
@@ -11,6 +11,8 @@
   "loc.input.help.target": "指定したターゲットをこのプロジェクトでビルドします。ターゲットが複数の場合には、セミコロンを使用して区切ります。",
   "loc.input.label.outputDir": "出力ディレクトリ",
   "loc.input.label.configuration": "構成",
+  "loc.input.label.clean": "消去",
+  "loc.input.help.clean": "ビルドの前に、クリーン ビルド (/t:clean) を実行します。",
   "loc.input.label.msbuildLocation": "MSBuild の場所",
   "loc.input.help.msbuildLocation": "必要に応じて、MSBuild へのパスを指定します。指定しない場合は、最新のバージョンが検索されます。",
   "loc.input.label.msbuildArguments": "MSBuild 引数",

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/ko-KR/resources.resjson
@@ -11,6 +11,8 @@
   "loc.input.help.target": "이 프로젝트에서 이 대상을 빌드하세요. 여러 대상을 구분하려면 세미콜론을 사용하세요.",
   "loc.input.label.outputDir": "출력 디렉터리",
   "loc.input.label.configuration": "구성",
+  "loc.input.label.clean": "클린",
+  "loc.input.help.clean": "빌드에 앞서 클린 빌드(/t:clean)를 실행합니다.",
   "loc.input.label.msbuildLocation": "MSBuild 위치",
   "loc.input.help.msbuildLocation": "원하는 경우 MSBuild의 경로를 제공하세요. 기본값은 최신 버전 검색입니다.",
   "loc.input.label.msbuildArguments": "MSBuild 인수",

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/ru-RU/resources.resjson
@@ -11,6 +11,8 @@
   "loc.input.help.target": "Выполнить сборку этих целевых объектов в этом проекте. Несколько целевых объектов указываются через точку с запятой.",
   "loc.input.label.outputDir": "Выходной каталог",
   "loc.input.label.configuration": "Конфигурация",
+  "loc.input.label.clean": "Очистить",
+  "loc.input.help.clean": "Выполните очистку сборки (/t:clean) перед сборкой.",
   "loc.input.label.msbuildLocation": "Расположение MSBuild",
   "loc.input.help.msbuildLocation": "При необходимости укажите путь к MSBuild. По умолчанию ищется последняя версия.",
   "loc.input.label.msbuildArguments": "Аргументы MSBuild",

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/zh-CN/resources.resjson
@@ -11,6 +11,8 @@
   "loc.input.help.target": "在此项目中生成这些目标。使用分号分隔多个目标。",
   "loc.input.label.outputDir": "输出目录",
   "loc.input.label.configuration": "配置",
+  "loc.input.label.clean": "清理",
+  "loc.input.help.clean": "在生成前运行清理生成(/t:clean)。",
   "loc.input.label.msbuildLocation": "MSBuild 位置",
   "loc.input.help.msbuildLocation": "可以选择提供 MSBuild 的路径。默认为搜索最新版本。",
   "loc.input.label.msbuildArguments": "MSBuild 参数",

--- a/Tasks/XamarinAndroid/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/XamarinAndroid/Strings/resources.resjson/zh-TW/resources.resjson
@@ -11,6 +11,8 @@
   "loc.input.help.target": "在此專案中建置這些目標。請使用分號以區隔多個目標。",
   "loc.input.label.outputDir": "輸出目錄",
   "loc.input.label.configuration": "組態",
+  "loc.input.label.clean": "清除",
+  "loc.input.help.clean": "在組建之前執行乾淨的組建 (/t:clean)。",
   "loc.input.label.msbuildLocation": "MSBuild 位置",
   "loc.input.help.msbuildLocation": "選擇性地提供 MSBuild 的路徑。其預設為搜尋最新版本。",
   "loc.input.label.msbuildArguments": "MSBuild 引數",

--- a/Tasks/XamarinAndroid/XamarinAndroid.ps1
+++ b/Tasks/XamarinAndroid/XamarinAndroid.ps1
@@ -2,6 +2,7 @@ param(
     [string]$project, 
     [string]$target, 
     [string]$configuration,
+    [string]$clean,
     [string]$outputDir,
     [string]$msbuildLocation, 
     [string]$msbuildArguments,
@@ -13,6 +14,7 @@ Write-Verbose "Entering script XamarinAndroid.ps1"
 Write-Verbose "project = $project"
 Write-Verbose "target = $target"
 Write-Verbose "configuration = $configuration"
+Write-Verbose "clean = $clean"
 Write-Verbose "outputDir = $outputDir"
 Write-Verbose "msbuildLocation = $msbuildLocation"
 Write-Verbose "msbuildArguments = $msbuildArguments"
@@ -53,6 +55,12 @@ if ($configuration)
 {
     Write-Verbose "adding configuration: $configuration"
     $args = "$args /p:configuration=$configuration"
+}
+
+if ($clean.ToLower() -eq 'true')
+{
+    Write-Verbose "adding /t:clean"
+    $args = "$args /t:clean"
 }
 
 if ($target)

--- a/Tasks/XamarinAndroid/task.json
+++ b/Tasks/XamarinAndroid/task.json
@@ -65,6 +65,14 @@
             "required": false
         },
         {
+            "name": "clean",
+            "type": "boolean",
+            "label": "Clean",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Run a clean build (/t:clean) prior to the build."
+        },
+        {
             "name": "msbuildLocation",
             "type": "string",
             "label": "MSBuild Location",

--- a/Tasks/XamarinAndroid/task.loc.json
+++ b/Tasks/XamarinAndroid/task.loc.json
@@ -65,6 +65,14 @@
       "required": false
     },
     {
+      "name": "clean",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.clean",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.clean"
+    },
+    {
       "name": "msbuildLocation",
       "type": "string",
       "label": "ms-resource:loc.input.label.msbuildLocation",

--- a/Tasks/XamarinAndroid/xamarinandroid.ts
+++ b/Tasks/XamarinAndroid/xamarinandroid.ts
@@ -11,6 +11,7 @@ var project = tl.getPathInput('project', true);
 var target = tl.getInput('target');
 var outputDir = tl.getInput('outputDir');
 var configuration = tl.getInput('configuration');
+var clean = tl.getBoolInput('clean');
 var xbuildLocation = tl.getPathInput('msbuildLocation');
 var msbuildArguments = tl.getInput('msbuildArguments');
 
@@ -65,6 +66,9 @@ var runxbuild = function (fn) {
 
         if (target) {
             xbuild.arg('/t:' + target);
+        }
+        if(clean) {
+            xbuild.arg('/t:Clean');
         }
         xbuild.arg('/t:PackageForAndroid');
         if (msbuildArguments) {

--- a/Tests/L0/XamarinAndroid/_suite.ts
+++ b/Tests/L0/XamarinAndroid/_suite.ts
@@ -27,6 +27,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '**/Single*.csproj');
 		tr.setInput('target', '');
+		tr.setInput('clean', 'false');
 		tr.setInput('outputDir', '');
 		tr.setInput('configuration', '');
 		tr.setInput('msbuildLocation', '');
@@ -54,6 +55,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		//tr.setInput('project', '**/*.csproj');
 		tr.setInput('target', '');
+		tr.setInput('clean', 'false');
 		tr.setInput('outputDir', '');
 		tr.setInput('configuration', '');
 		tr.setInput('msbuildLocation', '');
@@ -81,6 +83,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '**/home*.csproj');
 		tr.setInput('target', '');
+		tr.setInput('clean', 'false');
 		tr.setInput('outputDir', '');
 		tr.setInput('configuration', '');
 		tr.setInput('msbuildLocation', '');
@@ -108,6 +111,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '/user/build/fun/project.csproj');
 		tr.setInput('target', '');
+		tr.setInput('clean', 'false');
 		tr.setInput('outputDir', '');
 		tr.setInput('configuration', '');
 		tr.setInput('msbuildLocation', '');
@@ -135,6 +139,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '/user/build/fun/project2.csproj');
 		tr.setInput('target', '');
+		tr.setInput('clean', 'false');
 		tr.setInput('outputDir', '');
 		tr.setInput('configuration', '');
 		tr.setInput('msbuildLocation', '');
@@ -162,6 +167,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '**/Multiple*.csproj');
 		tr.setInput('target', '');
+		tr.setInput('clean', 'false');
 		tr.setInput('outputDir', '');
 		tr.setInput('configuration', '');
 		tr.setInput('msbuildLocation', '');
@@ -191,6 +197,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '**/Single*.csproj');
 		tr.setInput('target', '');
+		tr.setInput('clean', 'false');
 		tr.setInput('outputDir', '');
 		tr.setInput('configuration', '');
 		tr.setInput('msbuildLocation', '');
@@ -219,6 +226,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '**/Single*.csproj');
 		tr.setInput('target', '');
+		tr.setInput('clean', 'false');
 		tr.setInput('outputDir', '');
 		tr.setInput('configuration', '');
 		tr.setInput('msbuildLocation', '');
@@ -248,6 +256,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '**/Single*.csproj');
 		tr.setInput('target', '');
+		tr.setInput('clean', 'false');
 		tr.setInput('outputDir', '');
 		tr.setInput('configuration', '');
 		tr.setInput('msbuildLocation', '');
@@ -275,6 +284,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '**/Single*.csproj');
 		tr.setInput('target', '');
+		tr.setInput('clean', 'false');
 		tr.setInput('outputDir', '');
 		tr.setInput('configuration', '');
 		tr.setInput('msbuildLocation', '/home/bin2/');
@@ -305,6 +315,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '**/Single*.csproj');
 		tr.setInput('target', '');
+		tr.setInput('clean', 'false');
 		tr.setInput('outputDir', '');
 		tr.setInput('configuration', '');
 		tr.setInput('msbuildLocation', '/home/bin/INVALID');
@@ -332,6 +343,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '**/Single*.csproj');
 		tr.setInput('target', '"My Target"');
+		tr.setInput('clean', 'true');
 		tr.setInput('outputDir', '"/home/o u t/dir"');
 		tr.setInput('configuration', '"For Release"');
 		tr.setInput('msbuildArguments', '/m:1 "/p:temp=/home/temp dir/" /f');
@@ -341,7 +353,7 @@ describe('XamarinAndroid Suite', function() {
 		
 		tr.run()
 		.then(() => {
-            assert(tr.ran('/home/bin/xbuild /user/build/fun/project.csproj /t:My Target /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8'), 'it should have run xamarin android');
+            assert(tr.ran('/home/bin/xbuild /user/build/fun/project.csproj /t:My Target /t:Clean /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8'), 'it should have run xamarin android');
             assert(tr.invokedToolCount == 1, 'should have only run XamarinAndroid 1 time');
 			assert(tr.resultWasSet, 'task should have set a result');
 			assert(tr.stderr.length == 0, 'should not have written to stderr');
@@ -359,6 +371,7 @@ describe('XamarinAndroid Suite', function() {
 		var tr = new trm.TaskRunner('XamarinAndroid', true);
 		tr.setInput('project', '**/Multiple*.csproj');
 		tr.setInput('target', '"My Target"');
+		tr.setInput('clean', 'true');
 		tr.setInput('outputDir', '"/home/o u t/dir"');
 		tr.setInput('configuration', '"For Release"');
 		tr.setInput('msbuildArguments', '/m:1 "/p:temp=/home/temp dir/" /f');
@@ -368,9 +381,9 @@ describe('XamarinAndroid Suite', function() {
 		
 		tr.run()
 		.then(() => {
-            assert(tr.ran('/home/bin/xbuild /user/build/fun/project1.csproj /t:My Target /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8'), 'it should have run xamarin android 1');
-            assert(tr.ran('/home/bin/xbuild /user/build/fun/project2.csproj /t:My Target /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8'), 'it should have run xamarin android 2');
-            assert(tr.ran('/home/bin/xbuild /user/build/fun/project3.csproj /t:My Target /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8'), 'it should have run xamarin android 3');
+            assert(tr.ran('/home/bin/xbuild /user/build/fun/project1.csproj /t:My Target /t:Clean /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8'), 'it should have run xamarin android 1');
+            assert(tr.ran('/home/bin/xbuild /user/build/fun/project2.csproj /t:My Target /t:Clean /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8'), 'it should have run xamarin android 2');
+            assert(tr.ran('/home/bin/xbuild /user/build/fun/project3.csproj /t:My Target /t:Clean /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8'), 'it should have run xamarin android 3');
             assert(tr.invokedToolCount == 3, 'should have only run XamarinAndroid 3 times');
 			assert(tr.resultWasSet, 'task should have set a result');
 			assert(tr.stderr.length == 0, 'should not have written to stderr');

--- a/Tests/L0/XamarinAndroid/response.json
+++ b/Tests/L0/XamarinAndroid/response.json
@@ -27,19 +27,19 @@
             "code": 0,
             "stdout": "Xamarin android"
         },
-        "/home/bin/xbuild /user/build/fun/project.csproj /t:My Target /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8": {
+        "/home/bin/xbuild /user/build/fun/project.csproj /t:My Target /t:Clean /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8": {
             "code": 0,
             "stdout": "Xamarin android"            
         },
-        "/home/bin/xbuild /user/build/fun/project1.csproj /t:My Target /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8": {
+        "/home/bin/xbuild /user/build/fun/project1.csproj /t:My Target /t:Clean /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8": {
             "code": 0,
             "stdout": "Xamarin android"            
         },
-        "/home/bin/xbuild /user/build/fun/project2.csproj /t:My Target /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8": {
+        "/home/bin/xbuild /user/build/fun/project2.csproj /t:My Target /t:Clean /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8": {
             "code": 0,
             "stdout": "Xamarin android"            
         },
-        "/home/bin/xbuild /user/build/fun/project3.csproj /t:My Target /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8": {
+        "/home/bin/xbuild /user/build/fun/project3.csproj /t:My Target /t:Clean /t:PackageForAndroid /m:1 /p:temp=/home/temp dir/ /f /p:OutputPath=/home/o u t/dir /p:Configuration=For Release /p:JavaSdkDirectory=/user/local/bin/Java8": {
             "code": 0,
             "stdout": "Xamarin android"            
         }


### PR DESCRIPTION
It was already possible to do this, using "Clean" as target, but it is much easier from a UX perspective to use a checkbox, just like MSBuild Task does. All localized strings were copied from MSBuild Task, so they _should_ be correct.
